### PR TITLE
server writing to socket causes v0.10 test fails

### DIFF
--- a/test/jackpot.test.js
+++ b/test/jackpot.test.js
@@ -8,10 +8,7 @@ describe('jackpot', function () {
     , server;
 
   before(function before(done) {
-    server = net.createServer(function create(socket) {
-      socket.write('<3');
-    });
-
+    server = net.createServer();
     server.listen(port, host, done);
   });
 


### PR DESCRIPTION
@3rd-Eden is there a reason to have the server write to the socket?  This seems to be what causes the test failures on v0.10.
