### PR TITLE
handle timeout while trying to connect

### DIFF
--- a/test/jackpot.test.js
+++ b/test/jackpot.test.js
@@ -116,6 +116,26 @@ describe('jackpot', function () {
       });
     });
 
+    it('should emit an error on timeout when trying to establish connection', function (done) {
+      var pool = new ConnectionPool(10, {
+          retries: 0
+        })
+        , unroutable = '10.255.255.255'
+        , S = new net.Socket;
+
+      pool.factory(function factory() {
+        S.connect(port, unroutable);
+        S.setTimeout(100);
+        return S;
+      });
+
+      pool.allocate(function allocate(err, connection) {
+        var fn = function() { throw err };
+        expect(fn).to.throw(/Timed out while trying to establish connection/);
+        done();
+      });
+    });
+
     it('should NOT emit an error when we can establish a connection', function (done) {
       var pool = new ConnectionPool();
 


### PR DESCRIPTION
Without this, the callack fn in allocate will never be called if timeout is hit while trying to connect.  I looked at their the timeout() function I add could be handled in either(), but it seems like that would require something like:

``` javascript
  function either(err) {
    this.removeListener('error', either);
    this.removeListener('connect', either);
    this.removeListener('timeout', either);

    if (!err && !this.writable)
      err = new Error('Socket is not writable'); // Problem is whether there's a way to tell the socket timed out when trying to connect, or, is not writable for some other reason... Jackpot.listen will destroy the socket on timeout, which will make it not writable, but, directly calling a separate timeout function as in the pull request seems safer, since it is the higher level interface to know the socket timed out.

    // Add to the pool
    if (!err) self.pool.push(this);
    self.pending--;

    fn(err, this);
  }
```
