### PR TITLE
Fix for 'callback was already called issue': timeout listener was not being removed

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,6 +157,7 @@ Manager.prototype.allocate = function allocate(fn) {
   function either(err) {
     this.removeListener('error', either);
     this.removeListener('connect', either);
+    this.removeListener('timeout', timeout);
 
     // Add to the pool
     if (!err) self.pool.push(this);


### PR DESCRIPTION
Fix for 'callback was already called issue': timeout listener was not being removed
